### PR TITLE
Add  the line Run pip install Flask in Dockerfile

### DIFF
--- a/labs/07-building-an-image.md
+++ b/labs/07-building-an-image.md
@@ -67,6 +67,7 @@ It is a simple way to automate the image creation process. The best part is that
     ```docker
     RUN apt-get update -y
     RUN apt-get install -y python3 python3-pip python3-dev build-essential
+    RUN pip install Flask
     ```
 
 1. Let's add the files that make up the Flask Application.
@@ -116,6 +117,7 @@ It is a simple way to automate the image creation process. The best part is that
     # Install python and pip
     RUN apt-get update -y
     RUN apt-get install -y python3 python3-pip python3-dev build-essential
+    RUN pip install Flask
 
     # Install Python modules needed by the Python app
     COPY requirements.txt /usr/src/app/
@@ -261,9 +263,8 @@ The next step in this section is to run the image and see if it actually works.
 
 ```bash
 
-$ docker container run -p 8888:5000 --name myfirstapp myfirstapp
- * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
-```
+$ docker container run -d -p 8888:5000 --name myfirstapp myfirstapp
+ 
 
 Head over to `http://localhost:8888` or your server's URL and your app should be live.
 


### PR DESCRIPTION
When running the container on myfirstapp image, you will get the following error

 docker container run -p 8888:5000 --name myfirstapp myfirstapp
Traceback (most recent call last):
  File "/usr/src/app/app.py", line 2, in <module>
    from flask import Flask
  File "/usr/local/lib/python3.10/dist-packages/flask/__init__.py", line 19, in <module>
    from jinja2 import Markup, escape
ImportError: cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.10/dist-packages/jinja2/__init__.py)

The solution is 

1-add the following line in Dockerfile 

RUN pip install Flask

under 

# Install python and pip
    RUN apt-get update -y
    RUN apt-get install -y python3 python3-pip python3-dev build-essential.

2- Update the requirements.txt
Flask==2 instead Flask==1.0

3.- add the  -d flag to the command   docker container run -p 8888:5000 --name myfirstapp myfirstapp to let it run in the background
docker container run -d -p 8888:5000 --name myfirstapp myfirstapp